### PR TITLE
Fixes Issue #4

### DIFF
--- a/fastdns_hook
+++ b/fastdns_hook
@@ -60,7 +60,10 @@ class DnsUpdater(object):
         self.s.auth = EdgeGridAuth(*args, **kwargs)
 
     def acme_domain(self, domain):
-        return '_acme-challenge.' + domain
+        if domain:
+            return '_acme-challenge.' + domain
+        else:
+            return '_acme-challenge'
 
     def current_config(self, domain):
         zone = [None] + domain.split('.')


### PR DESCRIPTION
In case you do the challange for your root domain (e.g. example.com) self.name will be empty. Resulting in def acme_domain(self, domain): returning '_acme-challenge.' which does not match up in the cleaup method and therefore leaving all txt records in place.